### PR TITLE
Feature moveScriptsToEmbeddedResource

### DIFF
--- a/DbSync.Core/DbSync.Core.csproj
+++ b/DbSync.Core/DbSync.Core.csproj
@@ -65,18 +65,18 @@
     <Compile Include="XmlRecordDataReader.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Scripts\MergeWithDelete.sql">
+    <EmbeddedResource Include="Scripts\MergeWithDelete.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scripts\MergeWithDeleteWithAudit.sql">
+    </EmbeddedResource>
+    <EmbeddedResource Include="Scripts\MergeWithDeleteWithAudit.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scripts\MergeWithoutDelete.sql">
+    </EmbeddedResource>
+    <EmbeddedResource Include="Scripts\MergeWithoutDelete.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Scripts\MergeWithoutDeleteWithAudit.sql">
+    </EmbeddedResource>
+    <EmbeddedResource Include="Scripts\MergeWithoutDeleteWithAudit.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <None Include="DbSync.Core.nuspec" />

--- a/DbSync.Core/DbSync.Core.csproj
+++ b/DbSync.Core/DbSync.Core.csproj
@@ -65,18 +65,10 @@
     <Compile Include="XmlRecordDataReader.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Scripts\MergeWithDelete.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Scripts\MergeWithDeleteWithAudit.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Scripts\MergeWithoutDelete.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Scripts\MergeWithoutDeleteWithAudit.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </EmbeddedResource>
+    <EmbeddedResource Include="Scripts\MergeWithDelete.sql" />
+    <EmbeddedResource Include="Scripts\MergeWithDeleteWithAudit.sql" />
+    <EmbeddedResource Include="Scripts\MergeWithoutDelete.sql" />
+    <EmbeddedResource Include="Scripts\MergeWithoutDeleteWithAudit.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="DbSync.Core.nuspec" />

--- a/DbSync.Tests/DbSync.Tests.csproj
+++ b/DbSync.Tests/DbSync.Tests.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{10850B96-00E2-4F93-806B-3018E1808562}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DbSync.Tests</RootNamespace>
+    <AssemblyName>DbSync.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="MergeTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DbSync.Core\DbSync.Core.csproj">
+      <Project>{beadfc44-5fad-4434-9ca8-293533f8b426}</Project>
+      <Name>DbSync.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/DbSync.Tests/MergeTests.cs
+++ b/DbSync.Tests/MergeTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DbSync.Core;
+
+namespace DbSync.Tests
+{
+    [TestClass]
+    public class MergeTests
+    {
+        [TestMethod]
+        public void DoesGetSqlForMergeStrategyRun()
+        {
+            const string connectionString = @"Data Source=.;Database=tempdb;Integrated Security=True";
+
+            var settings = new JobSettings();
+            settings.ConnectionString = connectionString;
+            settings.Path = @"Data";
+            settings.UseAuditColumnsOnImport = false;
+            settings.IgnoreAuditColumnsOnExport = false;
+            settings.MergeStrategy = Merge.Strategy.MergeWithDelete;
+            settings.AuditColumns = new JobSettings.AuditSettings();
+            settings.Tables.Add(new Table()
+            {
+                Name = "dbo.SmallTable",
+            });
+
+            var sql = Merge.GetSqlForMergeStrategy(settings, "testTarget", "testSource", "testID", (new[] { "testColumn1", "testColumn2", "testColumn3" }));
+            Assert.IsTrue(sql.Contains("testSource"));
+            Assert.IsTrue(sql.Contains("testID"));
+            Assert.IsTrue(sql.Contains("testColumn1"));
+            Assert.IsTrue(sql.Contains("testColumn1"));
+            Assert.IsTrue(sql.Contains("DELETE"));
+        }
+    }
+}

--- a/DbSync.Tests/Properties/AssemblyInfo.cs
+++ b/DbSync.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DbSync.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DbSync.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("10850b96-00e2-4f93-806b-3018e1808562")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/DbSync.sln
+++ b/DbSync.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbSync", "DbSync\DbSync.csproj", "{60DA3ABD-79EA-4BFA-9D7C-1F39C4EBC908}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerformanceTests", "PerformanceTests\PerformanceTests.csproj", "{05F2F41E-F233-4D0B-A6D8-E52F2027B56C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbSync.Core", "DbSync.Core\DbSync.Core.csproj", "{BEADFC44-5FAD-4434-9CA8-293533F8B426}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbSync.Tests", "DbSync.Tests\DbSync.Tests.csproj", "{10850B96-00E2-4F93-806B-3018E1808562}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{BEADFC44-5FAD-4434-9CA8-293533F8B426}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BEADFC44-5FAD-4434-9CA8-293533F8B426}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BEADFC44-5FAD-4434-9CA8-293533F8B426}.Release|Any CPU.Build.0 = Release|Any CPU
+		{10850B96-00E2-4F93-806B-3018E1808562}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{10850B96-00E2-4F93-806B-3018E1808562}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{10850B96-00E2-4F93-806B-3018E1808562}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{10850B96-00E2-4F93-806B-3018E1808562}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Not sure if the SQL scripts are packaged as separate files for a good reason, but moved them into embedded resources because it seems tidier.

Also:
- made class full of static stuff static
- added simple unit-test to confirm that Merge class isn't completely broken by this.